### PR TITLE
#17 - Ensure the sid field is there so inserts always work.

### DIFF
--- a/src/hepcore.js
+++ b/src/hepcore.js
@@ -48,7 +48,8 @@ exports.processHep = function processHep(data,socket) {
 				"protocol_header": decoded.rcinfo,
 				"data_header": {},
 				"create_date": new Date(),
-				"raw": decoded.payload || ""
+				"raw": decoded.payload || "",
+				"sid": "no-call-id"
 		};
 		/* HEP Correlation ID as SID */
 		if (decoded.rcinfo.correlation_id) insert.sid = decoded.rcinfo.correlation_id;


### PR DESCRIPTION
This ensures that the sid value is always present, even if there is no call-id in the sip request. 

This fix stops malicious actors from avoid detection by not having a Call-ID header in their SIP packets, which would never get inserted into the database.